### PR TITLE
feat: Product 업데이트 및 삭제 기능 구현

### DIFF
--- a/src/main/java/com/java/luckyhankki/config/annotation/PickupDateValidator.java
+++ b/src/main/java/com/java/luckyhankki/config/annotation/PickupDateValidator.java
@@ -10,6 +10,10 @@ public class PickupDateValidator implements ConstraintValidator<PickupDate, Loca
 
     @Override
     public boolean isValid(LocalDateTime value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return true;
+        }
+
         LocalDate pickupDate = value.toLocalDate();
         LocalDate today = LocalDate.now();
         LocalDate tomorrow = today.plusDays(1);

--- a/src/main/java/com/java/luckyhankki/config/annotation/WonUnitValidator.java
+++ b/src/main/java/com/java/luckyhankki/config/annotation/WonUnitValidator.java
@@ -14,6 +14,9 @@ public class WonUnitValidator implements ConstraintValidator<WonUnit, Integer> {
 
     @Override
     public boolean isValid(Integer value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return true;
+        }
         return value % unit == 0;
     }
 }

--- a/src/main/java/com/java/luckyhankki/controller/ProductController.java
+++ b/src/main/java/com/java/luckyhankki/controller/ProductController.java
@@ -3,6 +3,7 @@ package com.java.luckyhankki.controller;
 import com.java.luckyhankki.dto.ProductDetailResponse;
 import com.java.luckyhankki.dto.ProductRequest;
 import com.java.luckyhankki.dto.ProductResponse;
+import com.java.luckyhankki.dto.ProductUpdateRequest;
 import com.java.luckyhankki.service.ProductService;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Pageable;
@@ -40,5 +41,20 @@ public class ProductController {
     @GetMapping
     public Slice<ProductResponse> getAllProducts(Pageable pageable) {
         return service.getAllProducts(pageable);
+    }
+
+    @PutMapping("/{productId}")
+    public ResponseEntity<Void> updateProduct(@PathVariable Long productId,
+                                              @Valid @RequestBody ProductUpdateRequest request) {
+        service.updateProduct(productId, request);
+
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
+    @DeleteMapping("/{productId}")
+    public ResponseEntity<Void> deleteProduct(@PathVariable Long productId) {
+        service.deleteProduct(productId);
+
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 }

--- a/src/main/java/com/java/luckyhankki/domain/product/Product.java
+++ b/src/main/java/com/java/luckyhankki/domain/product/Product.java
@@ -7,6 +7,7 @@ import com.java.luckyhankki.dto.ProductUpdateRequest;
 import jakarta.persistence.*;
 
 import java.time.LocalDateTime;
+import java.util.function.Consumer;
 
 @Entity
 public class Product {
@@ -148,11 +149,31 @@ public class Product {
     }
 
     /**
-     * Product 업데이트 처리
+     * ProductUpdateRequest 필드값에 null이 아니고, 기존 Product의 값과 다른 값이 들어올 경우 업데이트
      *
      * @param request ProductUpdateRequest
      */
     public void updateProduct(ProductUpdateRequest request) {
-        request.updateIfPresent(this);
+        updateField(this::setName, request.name(), this.name);
+        updateField(this::setPriceOriginal, request.priceOriginal(), this.priceOriginal);
+        updateField(this::setPriceDiscount, request.priceDiscount(), this.priceDiscount);
+        updateField(this::setStock, request.stock(), this.stock);
+        updateField(this::setDescription, request.description(), this.description);
+        updateField(this::setPickupStartDateTime, request.pickupStartDateTime(), this.pickupStartDateTime);
+        updateField(this::setPickupEndDateTime, request.pickupEndDateTime(), this.pickupEndDateTime);
+    }
+
+    /**
+     * 필드 업데이트 내부 메소드
+     *
+     * @param consumer     Product의 setter 메서드 참조
+     * @param newValue     ProductUpdateRequest로 들어온 새로운 값
+     * @param currentValue 현재 Product에 저장되어 있는 값
+     * @param <T>          필드 타입
+     */
+    private <T> void updateField(Consumer<T> consumer, T newValue, T currentValue) {
+        if (newValue != null && !newValue.equals(currentValue)) {
+            consumer.accept(newValue);
+        }
     }
 }

--- a/src/main/java/com/java/luckyhankki/domain/product/Product.java
+++ b/src/main/java/com/java/luckyhankki/domain/product/Product.java
@@ -3,6 +3,7 @@ package com.java.luckyhankki.domain.product;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.java.luckyhankki.domain.category.Category;
 import com.java.luckyhankki.domain.store.Store;
+import com.java.luckyhankki.dto.ProductUpdateRequest;
 import jakarta.persistence.*;
 
 import java.time.LocalDateTime;
@@ -72,28 +73,56 @@ public class Product {
         return name;
     }
 
+    public void setName(String name) {
+        this.name = name;
+    }
+
     public int getPriceOriginal() {
         return priceOriginal;
+    }
+
+    public void setPriceOriginal(int priceOriginal) {
+        this.priceOriginal = priceOriginal;
     }
 
     public int getPriceDiscount() {
         return priceDiscount;
     }
 
+    public void setPriceDiscount(int priceDiscount) {
+        this.priceDiscount = priceDiscount;
+    }
+
     public int getStock() {
         return stock;
+    }
+
+    public void setStock(int stock) {
+        this.stock = stock;
     }
 
     public String getDescription() {
         return description;
     }
 
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
     public LocalDateTime getPickupStartDateTime() {
         return pickupStartDateTime;
     }
 
+    public void setPickupStartDateTime(LocalDateTime pickupStartDateTime) {
+        this.pickupStartDateTime = pickupStartDateTime;
+    }
+
     public LocalDateTime getPickupEndDateTime() {
         return pickupEndDateTime;
+    }
+
+    public void setPickupEndDateTime(LocalDateTime pickupEndDateTime) {
+        this.pickupEndDateTime = pickupEndDateTime;
     }
 
     public boolean isActive() {
@@ -105,5 +134,25 @@ public class Product {
      */
     public void deactivate() {
         this.isActive = false;
+    }
+
+    /**
+     * 카테고리 변경
+     *
+     * @param category ProductUpdateRequest으로 들어온 새 카테고리
+     */
+    public void changeCategory(Category category) {
+        if (!this.category.equals(category)) {
+            this.category = category;
+        }
+    }
+
+    /**
+     * Product 업데이트 처리
+     *
+     * @param request ProductUpdateRequest
+     */
+    public void updateProduct(ProductUpdateRequest request) {
+        request.updateIfPresent(this);
     }
 }

--- a/src/main/java/com/java/luckyhankki/dto/ProductUpdateRequest.java
+++ b/src/main/java/com/java/luckyhankki/dto/ProductUpdateRequest.java
@@ -1,35 +1,70 @@
 package com.java.luckyhankki.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.java.luckyhankki.config.annotation.PickupDate;
 import com.java.luckyhankki.config.annotation.WonUnit;
-import jakarta.validation.constraints.*;
+import com.java.luckyhankki.domain.product.Product;
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
 
 import java.time.LocalDateTime;
+import java.util.function.Consumer;
 
 public record ProductUpdateRequest(
-        long categoryId,
+        Long categoryId,
 
         String name,
 
         @PositiveOrZero(message = "원래 가격은 0원 이상이어야 합니다.")
         @WonUnit(unit = 10)
-        int priceOriginal,
+        Integer priceOriginal,
 
         @PositiveOrZero(message = "할인 가격은 0원 이상이어야 합니다.")
         @WonUnit(unit = 10)
-        int priceDiscount,
+        Integer priceDiscount,
 
         @Positive(message = "수량은 1개 이상이어야 합니다.")
-        int stock,
+        Integer stock,
 
         String description,
 
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
         @FutureOrPresent(message = "픽업 시작 시간은 현재 시각 이후여야 합니다.")
+        @PickupDate
         LocalDateTime pickupStartDateTime,
 
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
         @FutureOrPresent(message = "픽업 종료 시간은 현재 시각 이후여야 합니다.")
+        @PickupDate
         LocalDateTime pickupEndDateTime
 ) {
+        /**
+         * ProductUpdateRequest 필드값에 null이 아니고, 기존 Product의 값과 다른 값이 들어올 경우 업데이트
+         *
+         * @param product 현재 저장되어 있는 Product
+         */
+        public void updateIfPresent(Product product) {
+                updateField(product::setName, name, product.getName());
+                updateField(product::setPriceOriginal, priceOriginal, product.getPriceOriginal());
+                updateField(product::setPriceDiscount, priceDiscount, product.getPriceDiscount());
+                updateField(product::setStock, stock, product.getStock());
+                updateField(product::setDescription, description, product.getDescription());
+                updateField(product::setPickupStartDateTime, pickupStartDateTime, product.getPickupStartDateTime());
+                updateField(product::setPickupEndDateTime, pickupEndDateTime, product.getPickupEndDateTime());
+        }
+
+        /**
+         * 필드 업데이트 내부 메소드
+         *
+         * @param consumer     Product의 setter 메서드 참조
+         * @param newValue     ProductUpdateRequest로 들어온 새로운 값
+         * @param currentValue 현재 Product에 저장되어 있는 값
+         * @param <T>          필드 타입
+         */
+        private <T> void updateField(Consumer<T> consumer, T newValue, T currentValue) {
+                if (newValue != null && !newValue.equals(currentValue)) {
+                        consumer.accept(newValue);
+                }
+        }
 }

--- a/src/main/java/com/java/luckyhankki/dto/ProductUpdateRequest.java
+++ b/src/main/java/com/java/luckyhankki/dto/ProductUpdateRequest.java
@@ -3,13 +3,11 @@ package com.java.luckyhankki.dto;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.java.luckyhankki.config.annotation.PickupDate;
 import com.java.luckyhankki.config.annotation.WonUnit;
-import com.java.luckyhankki.domain.product.Product;
 import jakarta.validation.constraints.FutureOrPresent;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.PositiveOrZero;
 
 import java.time.LocalDateTime;
-import java.util.function.Consumer;
 
 public record ProductUpdateRequest(
         Long categoryId,
@@ -39,32 +37,4 @@ public record ProductUpdateRequest(
         @PickupDate
         LocalDateTime pickupEndDateTime
 ) {
-        /**
-         * ProductUpdateRequest 필드값에 null이 아니고, 기존 Product의 값과 다른 값이 들어올 경우 업데이트
-         *
-         * @param product 현재 저장되어 있는 Product
-         */
-        public void updateIfPresent(Product product) {
-                updateField(product::setName, name, product.getName());
-                updateField(product::setPriceOriginal, priceOriginal, product.getPriceOriginal());
-                updateField(product::setPriceDiscount, priceDiscount, product.getPriceDiscount());
-                updateField(product::setStock, stock, product.getStock());
-                updateField(product::setDescription, description, product.getDescription());
-                updateField(product::setPickupStartDateTime, pickupStartDateTime, product.getPickupStartDateTime());
-                updateField(product::setPickupEndDateTime, pickupEndDateTime, product.getPickupEndDateTime());
-        }
-
-        /**
-         * 필드 업데이트 내부 메소드
-         *
-         * @param consumer     Product의 setter 메서드 참조
-         * @param newValue     ProductUpdateRequest로 들어온 새로운 값
-         * @param currentValue 현재 Product에 저장되어 있는 값
-         * @param <T>          필드 타입
-         */
-        private <T> void updateField(Consumer<T> consumer, T newValue, T currentValue) {
-                if (newValue != null && !newValue.equals(currentValue)) {
-                        consumer.accept(newValue);
-                }
-        }
 }

--- a/src/main/java/com/java/luckyhankki/service/ProductService.java
+++ b/src/main/java/com/java/luckyhankki/service/ProductService.java
@@ -9,6 +9,7 @@ import com.java.luckyhankki.domain.store.StoreRepository;
 import com.java.luckyhankki.dto.ProductDetailResponse;
 import com.java.luckyhankki.dto.ProductRequest;
 import com.java.luckyhankki.dto.ProductResponse;
+import com.java.luckyhankki.dto.ProductUpdateRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -128,5 +129,24 @@ public class ProductService {
                 product.pickupStartDateTime(),
                 product.pickupEndDateTime()
         ));
+    }
+
+    public void updateProduct(Long productId, ProductUpdateRequest request) {
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new RuntimeException("해당 상품이 존재하지 않습니다."));
+
+        if (request.categoryId() != null) {
+            Category category = categoryRepository.findById(request.categoryId())
+                    .orElseThrow(() -> new RuntimeException("존재하지 않는 카테고리입니다."));
+            product.changeCategory(category);
+        }
+
+        product.updateProduct(request);
+    }
+
+    public void deleteProduct(Long productId) {
+        //if 예약건이 없는 경우
+        productRepository.deleteById(productId);
+        //else 예외 던지기
     }
 }

--- a/src/test/java/com/java/luckyhankki/controller/ProductControllerTest.java
+++ b/src/test/java/com/java/luckyhankki/controller/ProductControllerTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.java.luckyhankki.dto.ProductDetailResponse;
 import com.java.luckyhankki.dto.ProductRequest;
 import com.java.luckyhankki.dto.ProductResponse;
+import com.java.luckyhankki.dto.ProductUpdateRequest;
 import com.java.luckyhankki.service.ProductService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -24,8 +25,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -198,5 +198,40 @@ class ProductControllerTest {
                 .andDo(print());
 
         verify(productService).getAllProducts(any(Pageable.class));
+    }
+
+    @Test
+    @DisplayName("상품 업데이트 웹 테스트")
+    void updateProduct() throws Exception {
+        Long productId = 1L;
+        ProductUpdateRequest productUpdateRequest = new ProductUpdateRequest(
+                null,
+                "초밥",
+                250000,
+                null,
+                null,
+                "name, priceOriginal, description 변경",
+                null,
+                null
+        );
+
+        mockMvc.perform(put("/products/{productId}", productId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(productUpdateRequest)))
+                        .andExpect(status().isNoContent())
+                .andDo(print());
+
+        verify(productService).updateProduct(eq(productId), any(ProductUpdateRequest.class));
+    }
+
+    @Test
+    @DisplayName("hard delete 웹 테스트")
+    void deleteProduct() throws Exception {
+        Long productId = 1L;
+
+        mockMvc.perform(delete("/products/{productId}", productId))
+                .andExpect(status().isOk());
+
+        verify(productService).deleteProduct(eq(productId));
     }
 }

--- a/src/test/java/com/java/luckyhankki/service/ProductServiceTest.java
+++ b/src/test/java/com/java/luckyhankki/service/ProductServiceTest.java
@@ -9,6 +9,7 @@ import com.java.luckyhankki.domain.store.StoreRepository;
 import com.java.luckyhankki.dto.ProductDetailResponse;
 import com.java.luckyhankki.dto.ProductRequest;
 import com.java.luckyhankki.dto.ProductResponse;
+import com.java.luckyhankki.dto.ProductUpdateRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -21,7 +22,8 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.AdditionalAnswers.returnsFirstArg;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -212,6 +214,46 @@ class ProductServiceTest {
         assertThat(response.productName()).isEqualTo(product.getName());
 
         verify(productRepository).findById(productId);
+    }
+
+    @Test
+    @DisplayName("상품 업데이트 테스트")
+    void updateProduct_success() {
+        long productId = 1L;
+        Store store = mock(Store.class);
+        Category category = mock(Category.class);
+
+        Product product = new Product(
+                store,
+                category,
+                "비빔밥",
+                10000,
+                8000,
+                1,
+                "육회비빔밥 입니다.",
+                LocalDateTime.now().plusHours(1),
+                LocalDateTime.now().plusHours(2)
+        );
+
+        when(productRepository.findById(productId))
+                .thenReturn(Optional.of(product));
+
+        ProductUpdateRequest request = new ProductUpdateRequest(
+                null,
+                 "우동",
+                null,
+                null,
+                2,
+                null,
+                null,
+                null
+        );
+
+        service.updateProduct(productId, request);
+
+        assertThat(product.getName()).isEqualTo("우동");
+        assertThat(product.getStock()).isEqualTo(2);
+        assertThat(product.getPriceOriginal()).isEqualTo(10000);
     }
 
     private static List<ProductResponse> getProductResponses(boolean isActive) {


### PR DESCRIPTION
## 추가사항

- Product 업데이트 및 삭제 기능 구현
- 삭제 기능은 추후 예약 및 결제 내역이 없을 경우에만 hard delete하는 기능 보완
- 테스트 코드 작성
- WonUnitValidator, PickupDateValidator의 value가 null 방지는 DTO에서 `@NotNull`로 방지