### PR TITLE
feat: 상품 조회 시 거리 가까운 순 조건 추가

### DIFF
--- a/src/main/java/com/java/luckyhankki/controller/ProductController.java
+++ b/src/main/java/com/java/luckyhankki/controller/ProductController.java
@@ -1,5 +1,6 @@
 package com.java.luckyhankki.controller;
 
+import com.java.luckyhankki.config.security.CustomUserDetails;
 import com.java.luckyhankki.dto.product.*;
 import com.java.luckyhankki.service.ProductService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -11,6 +12,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Product", description = "상품 관련 API")
@@ -51,11 +53,12 @@ public class ProductController {
 
     @Operation(summary = "조회 조건에 따른 상품 목록 조회", description = "조회 조건에 따라 활성화 상태의 등록된 상품을 조회합니다.")
     @GetMapping("/condition")
-    public Slice<ProductResponse> searchProductsByCondition(
+    public Slice<ProductWithDistanceResponse> searchProductsByCondition(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @Parameter(description = "상품 조회 조건") ProductSearchCondition condition,
             @ParameterObject Pageable pageable) {
 
-        return service.searchProductsByCondition(condition, pageable);
+        return service.searchProductsByCondition(userDetails, condition, pageable);
     }
 
     @Operation(summary = "상품 수정", description = "상품 ID에 해당하는 상품을 수정합니다.")

--- a/src/main/java/com/java/luckyhankki/domain/product/ProductRepositoryCustom.java
+++ b/src/main/java/com/java/luckyhankki/domain/product/ProductRepositoryCustom.java
@@ -1,10 +1,10 @@
 package com.java.luckyhankki.domain.product;
 
-import com.java.luckyhankki.dto.product.ProductResponse;
-import com.java.luckyhankki.dto.product.ProductSearchCondition;
+import com.java.luckyhankki.dto.product.ProductSearchRequest;
+import com.java.luckyhankki.dto.product.ProductWithDistanceResponse;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 public interface ProductRepositoryCustom {
-    Slice<ProductResponse> findAllByCondition(ProductSearchCondition condition, Pageable pageable);
+    Slice<ProductWithDistanceResponse> findAllByCondition(ProductSearchRequest request, Pageable pageable);
 }

--- a/src/main/java/com/java/luckyhankki/domain/product/ProductRepositoryImpl.java
+++ b/src/main/java/com/java/luckyhankki/domain/product/ProductRepositoryImpl.java
@@ -1,24 +1,24 @@
 package com.java.luckyhankki.domain.product;
 
-import com.java.luckyhankki.dto.product.ProductResponse;
-import com.java.luckyhankki.dto.product.ProductSearchCondition;
+import com.java.luckyhankki.dto.product.*;
 import com.java.luckyhankki.dto.product.ProductSearchCondition.PickupDateFilter;
 import com.java.luckyhankki.dto.product.ProductSearchCondition.SortType;
-import com.java.luckyhankki.dto.product.QProductResponse;
 import com.querydsl.core.types.Expression;
-import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 
 import static com.java.luckyhankki.domain.product.QProduct.product;
+import static com.querydsl.core.types.dsl.Expressions.numberTemplate;
 
 public class ProductRepositoryImpl implements ProductRepositoryCustom {
 
@@ -29,18 +29,23 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
     }
 
     @Override
-    public Slice<ProductResponse> findAllByCondition(ProductSearchCondition condition, Pageable pageable) {
-        List<ProductResponse> content = queryFactory
-                .select(new QProductResponse(
-                        product.id,
-                        product.store.name,
-                        product.category.name,
-                        product.name,
-                        product.priceOriginal,
-                        product.priceDiscount,
-                        product.stock,
-                        product.pickupStartDateTime,
-                        product.pickupEndDateTime)
+    public Slice<ProductWithDistanceResponse> findAllByCondition(ProductSearchRequest request, Pageable pageable) {
+        ProductSearchCondition condition = request.condition();
+        NumberExpression<Double> distance = calculateDistance(request.userLat(), request.userLon());
+
+        List<ProductWithDistanceResponse> content = queryFactory
+                .select(new QProductWithDistanceResponse(
+                            new QProductResponse(
+                                product.id,
+                                product.store.name,
+                                product.category.name,
+                                product.name,
+                                product.priceOriginal,
+                                product.priceDiscount,
+                                product.stock,
+                                product.pickupStartDateTime,
+                                product.pickupEndDateTime)
+                        , distance.castToNum(BigDecimal.class))
                 )
                 .from(product)
                 .where(
@@ -49,7 +54,7 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
                         pickupDateFilterEq(condition.pickupDate()),
                         keywordContains(condition.keyword())
                 )
-                .orderBy(getOrderSpecifier(condition))
+                .orderBy(getOrderSpecifier(condition, request))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
@@ -109,31 +114,52 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
     }
 
     /**
+     * Haversine을 이용한 사용자와 가게 간 거리 차이 구하기
+     *
+     * @param userLat   사용자 위도
+     * @param userLon   사용자 경도
+     * @return 사용자와 가게 간 거리 차이
+     */
+    private NumberExpression<Double> calculateDistance(Double userLat, Double userLon) {
+        // 위도/경도 필드
+        NumberExpression<Double> storeLat = product.store.latitude.doubleValue();
+        NumberExpression<Double> storeLon = product.store.longitude.doubleValue();
+
+        // Haversine 공식 사용
+        return numberTemplate(Double.class,
+                "6371 * acos(" +
+                        "cos(radians({0})) * cos(radians({1})) * " +
+                        "cos(radians({2}) - radians({3})) + " +
+                        "sin(radians({0})) * sin(radians({1}))" +
+                        ")",
+                userLat, storeLat, storeLon, userLon);
+    }
+
+    /**
      * 정렬 기준에 따라 OrderSpecifier 리턴
-     * - 상품 할인가격 오름차순 default (추후 거리순이 default 되도록 변경)
+     * - 거리 가까운 순 default
      *
      * @param condition       조회 조건
      * @return OrderSpecifier
      */
-    private OrderSpecifier<?> getOrderSpecifier(ProductSearchCondition condition) {
-        if (condition.sortType() == null) {
-            return new OrderSpecifier<>(Order.ASC, product.priceDiscount);
-        }
+    private OrderSpecifier<?> getOrderSpecifier(ProductSearchCondition condition, ProductSearchRequest request) {
+        SortType sortType = (condition.sortType() == null) ? SortType.DISTANCE : condition.sortType();
 
-        SortType sortType = condition.sortType();
-        return new OrderSpecifier<>(sortType.getOrder(), getTarget(sortType));
+        return new OrderSpecifier<>(sortType.getOrder(), getTarget(sortType, request));
     }
 
     /**
      * 정렬 대상 필드 매핑
-     * - 현재는 가격만 적용, 거리/평점은 추후 구현 예정
+     * - DISTANCE : 거리 가까운 순
+     * - TODO RATING
+     * - PRICE : 가격 낮은 순
      *
      * @param sortType      정렬 기준
      * @return Expression - 정렬 대상 필드
      */
-    private Expression getTarget(SortType sortType) {
+    private Expression getTarget(SortType sortType, ProductSearchRequest request) {
         return switch (sortType) {
-            case DISTANCE -> product.id;    //TODO 거리 정렬 구현 필요
+            case DISTANCE -> calculateDistance(request.userLat(), request.userLon());
             case RATING -> product.id;      //TODO 평점 정렬 구현 필요
             case PRICE -> product.priceDiscount;
         };

--- a/src/main/java/com/java/luckyhankki/domain/user/UserLocationProjection.java
+++ b/src/main/java/com/java/luckyhankki/domain/user/UserLocationProjection.java
@@ -1,0 +1,8 @@
+package com.java.luckyhankki.domain.user;
+
+import java.math.BigDecimal;
+
+public interface UserLocationProjection {
+    BigDecimal getLongitude();
+    BigDecimal getLatitude();
+}

--- a/src/main/java/com/java/luckyhankki/domain/user/UserRepository.java
+++ b/src/main/java/com/java/luckyhankki/domain/user/UserRepository.java
@@ -8,4 +8,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
 
     Optional<User> findByEmail(String username);
+
+    UserLocationProjection findUserLocationProjectionByEmail(String email);
 }

--- a/src/main/java/com/java/luckyhankki/dto/product/ProductSearchRequest.java
+++ b/src/main/java/com/java/luckyhankki/dto/product/ProductSearchRequest.java
@@ -1,0 +1,21 @@
+package com.java.luckyhankki.dto.product;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "상품 조회 요청 DTO(상품 조회 조건 DTO 포함)")
+public record ProductSearchRequest(
+
+        @Schema(description = "상품 조회 조건 요청 DTO")
+        @NotNull
+        ProductSearchCondition condition,
+
+        @Schema(description = "사용자 위도", example = "37.586671")
+        @NotNull
+        double userLat,
+
+        @Schema(description = "사용자 경도", example = "126.976112")
+        @NotNull
+        double userLon
+) {
+}

--- a/src/main/java/com/java/luckyhankki/dto/product/ProductWithDistanceResponse.java
+++ b/src/main/java/com/java/luckyhankki/dto/product/ProductWithDistanceResponse.java
@@ -1,0 +1,20 @@
+package com.java.luckyhankki.dto.product;
+
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import com.querydsl.core.annotations.QueryProjection;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.math.BigDecimal;
+
+@Schema(description = "상품 목록 조회 응답 DTO (거리 정보 포함)")
+@QueryProjection
+public record ProductWithDistanceResponse(
+
+        @JsonUnwrapped
+        @Schema(description = "상품 정보")
+        ProductResponse product,
+
+        @Schema(description = "사용자와 가게 간 거리 (km)", example = "2.5")
+        BigDecimal distance
+) {
+}

--- a/src/test/java/com/java/luckyhankki/domain/product/ProductTest.java
+++ b/src/test/java/com/java/luckyhankki/domain/product/ProductTest.java
@@ -8,6 +8,8 @@ import com.java.luckyhankki.domain.store.Store;
 import com.java.luckyhankki.domain.store.StoreRepository;
 import com.java.luckyhankki.dto.product.ProductResponse;
 import com.java.luckyhankki.dto.product.ProductSearchCondition;
+import com.java.luckyhankki.dto.product.ProductSearchRequest;
+import com.java.luckyhankki.dto.product.ProductWithDistanceResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -140,12 +142,17 @@ class ProductTest {
                 categoryBakeryId,
                 ProductSearchCondition.PickupDateFilter.TODAY,
                 null,
-                ProductSearchCondition.SortType.PRICE);
+                ProductSearchCondition.SortType.DISTANCE);
 
+        double userLon = 126.976112;
+        double userLat = 37.586671;
+
+        ProductSearchRequest request = new ProductSearchRequest(condition, userLat, userLon);
         PageRequest pageRequest = PageRequest.of(0, 10);
-        Slice<ProductResponse> result = productRepository.findAllByCondition(condition, pageRequest);
+        Slice<ProductWithDistanceResponse> result = productRepository.findAllByCondition(request, pageRequest);
 
         assertThat(result.getContent()).hasSize(1);
-        assertThat(result.getContent()).extracting("name").containsExactly("소금빵");
+        assertThat(result.getContent().get(0).distance()).isBetween(BigDecimal.valueOf(2.23), BigDecimal.valueOf(2.25));
+        assertThat(result.getContent().get(0).product().name()).isEqualTo("소금빵");
     }
 }


### PR DESCRIPTION
## 추가사항
- 사용자의 위도&경도, 가게의 위도&경도 좌표를 기준으로 거리를 계산->[하버사인 공식(Haversine Formula)](https://jdk0.tistory.com/44) 이용
---
## 변경사항
- 상품 조회 시 사용자와 가게와의 거리도 응답 하도록 응답 DTO 생성
- 정렬 방식 미선택 시 거리(DISTANCE) 가까운 순으로 정렬하도록 수정