### PR TITLE
feat: 관리자 기능 구현

### DIFF
--- a/src/main/java/com/java/luckyhankki/config/security/SecurityConfig.java
+++ b/src/main/java/com/java/luckyhankki/config/security/SecurityConfig.java
@@ -58,6 +58,7 @@ public class SecurityConfig {
                                 //Swagger 관련 URL
                                 .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
 
+                                .requestMatchers("/admins/**").hasRole("ADMIN")
                                 .requestMatchers(POST, "/categories", "/stores").hasRole("ADMIN")
                                 .requestMatchers(PUT, "/categories/**").hasRole("ADMIN")
 

--- a/src/main/java/com/java/luckyhankki/controller/AdminController.java
+++ b/src/main/java/com/java/luckyhankki/controller/AdminController.java
@@ -1,0 +1,57 @@
+package com.java.luckyhankki.controller;
+
+import com.java.luckyhankki.dto.admin.AdminStoreResponse;
+import com.java.luckyhankki.dto.admin.AdminStoreWithSellerResponse;
+import com.java.luckyhankki.service.AdminService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+
+/**
+ * TODO
+ * 1. 신고 내역 조회
+ * 2. 신고 내역 조치
+ * 3. 가게 반려 처리
+ */
+@Tag(name = "Admin", description = "관리자 관련 API")
+@RestController
+@RequestMapping("/admins")
+public class AdminController {
+
+    private final AdminService adminService;
+
+    public AdminController(AdminService adminService) {
+        this.adminService = adminService;
+    }
+
+    @Operation(summary = "등록된 모든 가게 조회", description = "관리자가 등록된 가게 목록을 조회합니다.")
+    @GetMapping("/stores")
+    public ResponseEntity<List<AdminStoreResponse>> findAllStore() {
+        List<AdminStoreResponse> stores = adminService.findAllStore();
+
+        return ResponseEntity.status(HttpStatus.OK).body(stores);
+
+    }
+
+    @Operation(summary = "가게 및 판매자 조회", description = "관리자가 가게 ID에 해당하는 가게 및 판매자 정보를 조회합니다.")
+    @GetMapping("/stores/{storeId}")
+    public ResponseEntity<AdminStoreWithSellerResponse> findStoreByStoreId(@Parameter(description = "가게 ID") @PathVariable long storeId) {
+        AdminStoreWithSellerResponse result = adminService.findStoreByStoreId(storeId);
+
+        return ResponseEntity.status(HttpStatus.OK).body(result);
+    }
+
+    @Operation(summary = "가게 승인 처리", description = "관리자가 등록된 가게를 검토 후 승인 처리를 합니다.")
+    @PutMapping("/stores/{storeId}")
+    public ResponseEntity<Void> approveStore(@PathVariable("storeId") long storeId) {
+        adminService.approveStore(storeId);
+
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+}

--- a/src/main/java/com/java/luckyhankki/domain/store/Store.java
+++ b/src/main/java/com/java/luckyhankki/domain/store/Store.java
@@ -1,5 +1,6 @@
 package com.java.luckyhankki.domain.store;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.java.luckyhankki.domain.seller.Seller;
 import jakarta.persistence.*;
 import org.hibernate.annotations.CreationTimestamp;
@@ -37,6 +38,7 @@ public class Store {
     @Column(nullable = false, precision = 10, scale = 6)
     private BigDecimal latitude;
 
+    @JsonProperty("isApproved")
     @Column(nullable = false)
     private boolean isApproved;
 
@@ -51,8 +53,9 @@ public class Store {
     @Column(insertable = false)
     private LocalDateTime updatedAt;
 
+    @JsonProperty("isActive")
     @Column(nullable = false)
-    private boolean isDeleted;
+    private boolean isActive;
 
     protected Store() {}
 
@@ -65,7 +68,7 @@ public class Store {
         this.latitude = latitude;
         this.isApproved = false;
         this.reportCount = 0;
-        this.isDeleted = false;
+        this.isActive = false;
     }
 
     public Long getId() {
@@ -116,7 +119,38 @@ public class Store {
         return updatedAt;
     }
 
-    public boolean isDeleted() {
-        return isDeleted;
+    public boolean isActive() {
+        return isActive;
+    }
+
+    /**
+     * 관리자가 가게를 승인하는 메소드
+     */
+    public void approveStore() {
+        this.isApproved = true;
+        this.isActive = true;
+    }
+
+    /**
+     * 경고 누적 처리
+     */
+    public void addReport() {
+        this.reportCount++;
+        if (this.reportCount >= 3) {
+            deactivate();
+        }
+    }
+
+    /**
+     * 경고 3회 누적 시 비활성화 처리
+     */
+    private void deactivate() {
+        this.isActive = false;
+    }
+
+    @Override
+    public String toString() {
+        return "Store{id=%d, name='%s', phone='%s', address='%s', longitude=%s, latitude=%s, isApproved=%s, reportCount=%d, createdAt=%s, updatedAt=%s, isDeleted=%s}"
+                .formatted(id, name, phone, address, longitude, latitude, isApproved, reportCount, createdAt, updatedAt, isActive);
     }
 }

--- a/src/main/java/com/java/luckyhankki/domain/store/StoreRepository.java
+++ b/src/main/java/com/java/luckyhankki/domain/store/StoreRepository.java
@@ -1,5 +1,6 @@
 package com.java.luckyhankki.domain.store;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -10,4 +11,8 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
 
     //승인된 가게 조회
     Optional<Store> findByIdAndIsApprovedTrue(Long storeId);
+
+    @EntityGraph(attributePaths = {"seller"})
+    Store findStoreAndSellerById(Long storeId);
+
 }

--- a/src/main/java/com/java/luckyhankki/dto/admin/AdminSellerResponse.java
+++ b/src/main/java/com/java/luckyhankki/dto/admin/AdminSellerResponse.java
@@ -1,0 +1,20 @@
+package com.java.luckyhankki.dto.admin;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "관리자 전용 판매자 조회 응답 DTO")
+public record AdminSellerResponse(
+
+        @Schema(description = "판매자 ID", example = "1")
+        long id,
+
+        @Schema(description = "사업자등록번호", example = "1234567890")
+        String businessNumber,
+
+        @Schema(description = "판매자명", example = "홍길동")
+        String sellerName,
+
+        @Schema(description = "판매자 이메일", example = "test@test.com")
+        String email
+) {
+}

--- a/src/main/java/com/java/luckyhankki/dto/admin/AdminStoreResponse.java
+++ b/src/main/java/com/java/luckyhankki/dto/admin/AdminStoreResponse.java
@@ -1,0 +1,33 @@
+package com.java.luckyhankki.dto.admin;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "관리자 전용 가게 조회 응답 DTO")
+public record AdminStoreResponse(
+
+        @Schema(description = "가게 ID", example = "1")
+        Long id,
+
+        @Schema(description = "가게명", example = "길동국밥")
+        String name,
+
+        @Schema(description = "가게 전화번호", example = "03112341234")
+        String phone,
+
+        @Schema(description = "가게 주소", example = "경기도 수원시 XX구 XX대로")
+        String address,
+
+        @Schema(description = "가게 승인 여부", example = "true")
+        boolean isApproved,
+
+        @Schema(description = "신고 누적 수", example = "0")
+        int reportCount,
+
+        @Schema(description = "가게 등록 일시", example = "2025-07-07 17:30:00")
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/java/luckyhankki/dto/admin/AdminStoreWithSellerResponse.java
+++ b/src/main/java/com/java/luckyhankki/dto/admin/AdminStoreWithSellerResponse.java
@@ -1,0 +1,14 @@
+package com.java.luckyhankki.dto.admin;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "관리자 전용 가게 및 판매자 조회 응답 DTO")
+public record AdminStoreWithSellerResponse(
+
+        @Schema(description = "관리자 전용 가게 조회 응답 DTO")
+        AdminStoreResponse adminStoreResponse,
+
+        @Schema(description = "관리자 전용 판매자 조회 응답 DTO")
+        AdminSellerResponse adminSellerResponse
+) {
+}

--- a/src/main/java/com/java/luckyhankki/service/AdminService.java
+++ b/src/main/java/com/java/luckyhankki/service/AdminService.java
@@ -1,0 +1,78 @@
+package com.java.luckyhankki.service;
+
+import com.java.luckyhankki.domain.report.ReportRepository;
+import com.java.luckyhankki.domain.seller.Seller;
+import com.java.luckyhankki.domain.seller.SellerRepository;
+import com.java.luckyhankki.domain.store.Store;
+import com.java.luckyhankki.domain.store.StoreRepository;
+import com.java.luckyhankki.dto.admin.AdminSellerResponse;
+import com.java.luckyhankki.dto.admin.AdminStoreResponse;
+import com.java.luckyhankki.dto.admin.AdminStoreWithSellerResponse;
+import com.java.luckyhankki.exception.CustomException;
+import com.java.luckyhankki.exception.ErrorCode;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+
+@Service
+public class AdminService {
+
+    private final StoreRepository storeRepository;
+    private final SellerRepository sellerRepository;
+    private final ReportRepository reportRepository;
+
+    public AdminService(StoreRepository storeRepository, SellerRepository sellerRepository, ReportRepository reportRepository) {
+        this.storeRepository = storeRepository;
+        this.sellerRepository = sellerRepository;
+        this.reportRepository = reportRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public List<AdminStoreResponse> findAllStore() {
+        return storeRepository.findAll()
+                .stream()
+                .map(store -> new AdminStoreResponse(
+                        store.getId(),
+                        store.getName(),
+                        store.getPhone(),
+                        store.getAddress(),
+                        store.isApproved(),
+                        store.getReportCount(),
+                        store.getCreatedAt()
+                ))
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public AdminStoreWithSellerResponse findStoreByStoreId(long storeId) {
+        Store store = storeRepository.findStoreAndSellerById(storeId);
+        AdminStoreResponse storeResponse = new AdminStoreResponse(
+                store.getId(),
+                store.getName(),
+                store.getPhone(),
+                store.getAddress(),
+                store.isApproved(),
+                store.getReportCount(),
+                store.getCreatedAt()
+        );
+
+        Seller seller = store.getSeller();
+        AdminSellerResponse sellerResponse = new AdminSellerResponse(
+                seller.getId(),
+                seller.getBusinessNumber(),
+                seller.getName(),
+                seller.getEmail()
+        );
+
+        return new AdminStoreWithSellerResponse(storeResponse, sellerResponse);
+    }
+
+    @Transactional
+    public void approveStore(long storeId) {
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new CustomException(ErrorCode.STORE_NOT_FOUND));
+        store.approveStore();
+    }
+}

--- a/src/test/java/com/java/luckyhankki/controller/AdminControllerTest.java
+++ b/src/test/java/com/java/luckyhankki/controller/AdminControllerTest.java
@@ -1,0 +1,121 @@
+package com.java.luckyhankki.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.java.luckyhankki.dto.admin.AdminSellerResponse;
+import com.java.luckyhankki.dto.admin.AdminStoreResponse;
+import com.java.luckyhankki.dto.admin.AdminStoreWithSellerResponse;
+import com.java.luckyhankki.service.AdminService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AdminController.class)
+@WithMockUser(username = "test", roles = "ADMIN")
+class AdminControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AdminService adminService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("가게 목록 조회 웹 테스트")
+    void findAllStore() throws Exception {
+        AdminStoreResponse store1 = new AdminStoreResponse(
+                1L,
+                "길동카페",
+                "021231234",
+                "경기도 수원시",
+                true,
+                0,
+                LocalDateTime.now()
+        );
+        AdminStoreResponse store2 = new AdminStoreResponse(
+                2L,
+                "맥 디저트",
+                "0311231234",
+                "경기도 안양시",
+                false,
+                1,
+                LocalDateTime.now()
+        );
+        List<AdminStoreResponse> responses = List.of(store1, store2);
+        given(adminService.findAllStore()).willReturn(responses);
+
+        mockMvc.perform(get("/admins/stores")
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.size()").value(responses.size()))
+                .andExpect(jsonPath("$[0].name").value("길동카페"))
+                .andExpect(jsonPath("$[1].isApproved").value(false))
+                .andDo(print());
+
+        verify(adminService).findAllStore();
+    }
+
+    @Test
+    @DisplayName("가게 및 판매자 조회 웹 테스트")
+    void findStoreByStoreId() throws Exception {
+        long storeId = 1L;
+        AdminStoreResponse store = new AdminStoreResponse(
+                storeId,
+                "길동카페",
+                "021231234",
+                "경기도 수원시",
+                true,
+                0,
+                LocalDateTime.now()
+        );
+
+        AdminSellerResponse seller = new AdminSellerResponse(
+                1L,
+                "1234567890",
+                "홍길동",
+                "test@test.com"
+        );
+        AdminStoreWithSellerResponse storeWithSeller = new AdminStoreWithSellerResponse(store, seller);
+
+        given(adminService.findStoreByStoreId(storeId)).willReturn(storeWithSeller);
+
+        mockMvc.perform(get("/admins/stores/{storeId}", storeId)
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.adminStoreResponse.name").value("길동카페"))
+                .andExpect(jsonPath("$.adminSellerResponse.sellerName").value("홍길동"))
+                .andDo(print());
+
+        verify(adminService).findStoreByStoreId(storeId);
+    }
+
+    @Test
+    @DisplayName("가게 승인 웹 테스트")
+    void approveStore() throws Exception {
+        long storeId = 1L;
+
+        mockMvc.perform(put("/admins/stores/{storeId}", storeId)
+                .with(csrf()))
+                .andExpect(status().isNoContent());
+
+        verify(adminService).approveStore(storeId);
+    }
+}

--- a/src/test/java/com/java/luckyhankki/domain/store/StoreTest.java
+++ b/src/test/java/com/java/luckyhankki/domain/store/StoreTest.java
@@ -1,6 +1,7 @@
 package com.java.luckyhankki.domain.store;
 
 import com.java.luckyhankki.domain.seller.Seller;
+import com.java.luckyhankki.domain.seller.SellerRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,6 +20,9 @@ class StoreTest {
     @Autowired
     private StoreRepository storeRepository;
 
+    @Autowired
+    private SellerRepository sellerRepository;
+
     @Test
     @DisplayName("가게 등록 성공")
     void save() {
@@ -36,5 +40,28 @@ class StoreTest {
         Optional<Store> optionalStore = storeRepository.findById(savedStore.getId());
 
         assertThat(optionalStore).isPresent();
+    }
+
+    @Test
+    @DisplayName("가게 조회 시 판매자 함께 조회")
+    void findByIdWithSeller() {
+        Seller seller = new Seller("1234567890", "판매자1", "password123", "seller@test.com");
+        sellerRepository.save(seller);
+
+        Store store = new Store(
+                seller,
+                "가게명1",
+                "02-1234-5678",
+                "서울특별시 종로구 청와대로 1",
+                BigDecimal.valueOf(126.978414),
+                BigDecimal.valueOf(37.566680)
+        );
+
+        Store savedStore = storeRepository.save(store);
+        System.out.println(savedStore.getId());
+
+        Store result = storeRepository.findStoreAndSellerById(savedStore.getId());
+        assertThat(result.getName()).isEqualTo(savedStore.getName());
+        assertThat(result.getSeller().getEmail()).isEqualTo(savedStore.getSeller().getEmail());
     }
 }

--- a/src/test/java/com/java/luckyhankki/service/AdminServiceTest.java
+++ b/src/test/java/com/java/luckyhankki/service/AdminServiceTest.java
@@ -1,0 +1,106 @@
+package com.java.luckyhankki.service;
+
+import com.java.luckyhankki.domain.seller.Seller;
+import com.java.luckyhankki.domain.seller.SellerRepository;
+import com.java.luckyhankki.domain.store.Store;
+import com.java.luckyhankki.domain.store.StoreRepository;
+import com.java.luckyhankki.dto.admin.AdminStoreResponse;
+import com.java.luckyhankki.dto.admin.AdminStoreWithSellerResponse;
+import com.java.luckyhankki.exception.CustomException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(SpringExtension.class)
+class AdminServiceTest {
+
+    @InjectMocks
+    private AdminService adminService;
+
+    @Mock
+    private StoreRepository storeRepository;
+
+    @Mock
+    private SellerRepository sellerRepository;
+
+    @Test
+    @DisplayName("등록된 모든 가게 조회")
+    void findAllStore() {
+        Store store1 = mock(Store.class);
+        Store store2 = mock(Store.class);
+
+        when(storeRepository.findAll()).thenReturn(List.of(store1, store2));
+
+        List<AdminStoreResponse> result = adminService.findAllStore();
+
+        assertThat(result).hasSize(2);
+
+        verify(storeRepository).findAll();
+    }
+
+    @Test
+    @DisplayName("판매자 정보 포함 가게 조회")
+    void findStoreByStoreId() {
+        Seller seller = mock(Seller.class);
+        when(seller.getBusinessNumber()).thenReturn("1234567890");
+
+        long storeId = 1L;
+        Store store = new Store(seller, "길동카페", "021231234", "경기도 수원시", BigDecimal.valueOf(36.123123), BigDecimal.valueOf(126.123123));
+
+        when(storeRepository.findStoreAndSellerById(storeId)).thenReturn(store);
+
+        AdminStoreWithSellerResponse response = adminService.findStoreByStoreId(storeId);
+
+        assertThat(response.adminSellerResponse().businessNumber()).isEqualTo("1234567890");
+        assertThat(response.adminStoreResponse().name()).isEqualTo("길동카페");
+
+        verify(storeRepository).findStoreAndSellerById(storeId);
+    }
+
+    @Test
+    @DisplayName("가게 승인 성공")
+    void approveStore_success() {
+        Seller seller = mock(Seller.class);
+        when(seller.getBusinessNumber()).thenReturn("1234567890");
+
+        long storeId = 1L;
+        Store store = new Store(
+                seller,
+                "길동카페",
+                "021231234",
+                "경기도 수원시",
+                BigDecimal.valueOf(126.123123),
+                BigDecimal.valueOf(36.123123));
+
+        when(storeRepository.findById(storeId)).thenReturn(Optional.of(store));
+        assertThat(store.isApproved()).isFalse();
+
+        adminService.approveStore(storeId);
+        assertThat(store.isApproved()).isTrue();
+
+        verify(storeRepository).findById(storeId);
+    }
+
+    @Test
+    @DisplayName("가게 승인 실패 - 가게 정보 찾을 수 없음")
+    void approveStore_throwsException_whenStoreNotFound() {
+        long storeId = 99L;
+
+        when(storeRepository.findById(storeId)).thenReturn(Optional.empty());
+        assertThatThrownBy(() -> adminService.approveStore(storeId))
+                .isInstanceOf(CustomException.class);
+
+        verify(storeRepository).findById(99L);
+    }
+}


### PR DESCRIPTION
## 추가사항
- 관리자가 가게 및 판매자 조회
- 판매자가 가게를 등록하면 관리자가 가게 승인 처리
- 테스트 코드 작성
---
## 변경사항
- `/admins`로 들어오는 모든 요청은 ADMIN 권한을 갖는 관리자만 갖도록 SecurityConfig 수정
---
## TODO
- [ ] 신고 관련 기능 구현 후 관리자가 신고 처리 하는 기능 구현